### PR TITLE
cd: use built-in GITHUB_TOKEN for ghcr login

### DIFF
--- a/.github/workflows/cd_build_and_push.yaml
+++ b/.github/workflows/cd_build_and_push.yaml
@@ -99,7 +99,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
Main CD fails at registry login with `Password required` — the repo has no `GH_TOKEN` Actions secret anymore ([failed run](https://github.com/Mad-Deecent/moondream-server/actions/runs/29178516423)). The build job already has `packages: write`, so the built-in `GITHUB_TOKEN` covers the ghcr push with no PAT to provision or rotate.